### PR TITLE
putOne and putMany trigger mongoose middleware

### DIFF
--- a/test/normal_schema/put/put_many.coffee
+++ b/test/normal_schema/put/put_many.coffee
@@ -1,6 +1,7 @@
 fibrous = require 'fibrous'
 mongoose = require 'mongoose'
 expect = require('chai').expect
+sinon = require 'sinon'
 {suite, given} = require '../../support/helpers'
 
 ResourceSchema = require '../../..'
@@ -58,19 +59,42 @@ suite 'PUT many', ({withModel, withServer}) ->
       expect(@response.statusCode).to.equal 200
       expect(@response.body).to.deep.equal []
 
-  describe 'edge cases', ->
-    describe 'default on mongoose model', ->
-      withModel (mongoose) ->
-        mongoose.Schema
-          name: {type: String, default: 'foo'}
+  given 'default on mongoose model', ->
+    withModel (mongoose) ->
+      mongoose.Schema
+        name: {type: String, default: 'foo'}
 
-      withServer (app) ->
-        @resource = new ResourceSchema @model, {'_id', 'name'}
-        app.put '/bar', @resource.put(), @resource.send
+    withServer (app) ->
+      @resource = new ResourceSchema @model, {'_id', 'name'}
+      app.put '/bar', @resource.put(), @resource.send
 
-      it 'uses the mongoose schema defaults', fibrous ->
-        _id = new mongoose.Types.ObjectId()
-        response = @request.sync.put "/bar",
-          json: [{_id}]
-        expect(response.body[0]).to.have.property '_id'
-        expect(response.body[0]).to.have.property 'name', 'foo'
+    it 'uses the mongoose schema defaults', fibrous ->
+      _id = new mongoose.Types.ObjectId()
+      response = @request.sync.put "/bar",
+        json: [{_id}]
+      expect(response.body[0]).to.have.property '_id'
+      expect(response.body[0]).to.have.property 'name', 'foo'
+
+  given 'save hook on mongoose model', ->
+    saveSpy = sinon.spy()
+
+    withModel (mongoose) ->
+      schema = mongoose.Schema
+        name: String
+
+      schema.pre 'save', (next) ->
+        saveSpy()
+        next()
+
+    withServer (app) ->
+      @resource = new ResourceSchema @model, {'_id', 'name'}
+      app.put '/fruit', @resource.put(), @resource.send
+
+    beforeEach fibrous ->
+      @apple = @model.sync.create name: 'apple'
+      @banana = @model.sync.create name: 'banana'
+      saveSpy.reset()
+
+    it 'calls the save hook for each resource', fibrous ->
+      @request.sync.put "/fruit", json: [{_id: @apple._id}, {_id: @banana._id}]
+      expect(saveSpy.callCount).to.equal 2


### PR DESCRIPTION
POSTs with resource schema trigger [mongoose document middleware](http://mongoosejs.com/docs/middleware.html) like save hooks and validation, but PUTs did not.

Instead of using `findOneAndUpdate` which goes directly to MongoDB, PUT now does a `findOne()` and `save()` and triggers the document middleware like POSTs.