### PR TITLE
Allow getters for synthetic primary keys

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -97,7 +97,11 @@ module.exports = class ResourceSchema
 
       idValue = req.params[paramId]
       query = {}
-      query[paramId] = idValue
+      if @schema[paramId]?.field
+        query[@schema[paramId].field] = idValue
+      else
+        query[paramId] = idValue
+
       try
         @_convertTypes(query)
       catch err


### PR DESCRIPTION
i.e., if you have a resource that looks like this:

```js
var resource = new ResourceSchema(Model, {primaryKey: 'foo.bar'})
```

then you should be able to do something like this:

```js
app.get('/resource/:primaryKey', resource.get('primaryKey'))
```

And have `GET /resource/quux` do a query like `Model.find('foo:bar': 'quux')`.