### PR TITLE
getOne() and getMany() make lean queries by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.0
+
+## Breaking Changes
+- GET calls now make a lean query. If you need access to mongoose defaults, virtuals, etc. use `{fat: true}` as an option when defining the Resource.
+
 # 0.19.0
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ schema = {
 
 ### get: function(model, context)
 
-- **model** - corresponding mongoose model for requested resource
+- **model** - corresponding POJO model for requested resource (use the `fat: true` option on the ResourceSchema to get a mongoose model)
 - **context** - object containing req, res, next, and resolved values (see "resolve" for details)
 
 Dynamically get the value whenever a resource is requested.
@@ -183,7 +183,7 @@ Dynamically get the value whenever a resource is requested.
 var schema = {
   'fullName': {
     get: function (resource, context) {
-      resource.firtName + ' ' + resource.lastName
+      resource.firstName + ' ' + resource.lastName
     }
   }
 }

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -115,6 +115,9 @@ module.exports = class ResourceSchema
         return next boom.wrap err
 
       modelQuery = @Model.findOne(query)
+
+      modelQuery.lean() if not @options.fat
+
       modelQuery.exec().then (model) =>
         return next boom.notFound("No resources found with #{paramId} of #{idValue}") if not model?
         @_sendResource(model, requestContext)
@@ -137,6 +140,8 @@ module.exports = class ResourceSchema
 
       sort = @_getSort req.query
       modelQuery.sort(sort) if sort
+
+      modelQuery.lean() if not @options.fat
 
       q.all [
         modelQuery.exec()

--- a/test/normal_schema/get/get_many.coffee
+++ b/test/normal_schema/get/get_many.coffee
@@ -756,10 +756,10 @@ suite 'GET many', ({withModel, withServer}) ->
           name: {type: String, default: 'foo'}
 
       withServer (app) ->
-        @resource = new ResourceSchema @model, {'_id', 'name'}
+        @resource = new ResourceSchema @model, {'_id', 'name'}, {fat: true}
         app.get '/bar', @resource.get(), @resource.send
 
-      it 'uses the mongoose schema defaults', fibrous ->
+      it 'uses the mongoose schema defaults with the fat model option', fibrous ->
         _id = new mongoose.Types.ObjectId()
         @model.collection.sync.insert {_id}
         response = @request.sync.get "/bar"
@@ -769,14 +769,12 @@ suite 'GET many', ({withModel, withServer}) ->
 
     describe 'default limit of 1000', ->
       withModel (mongoose) ->
-        mongoose.Schema name: String
-
-      beforeEach ->
-        @resource = new ResourceSchema @model
+        mongoose.Schema
+          name: String
 
       withServer (app) ->
+        @resource = new ResourceSchema @model, {'_id', 'name'}
         app.get '/res/', @resource.get(), @resource.send
-        app
 
       it 'sets a default limit of 1000', fibrous ->
         [0...1050].forEach (i) => @model.sync.create name: "model_#{i}"

--- a/test/normal_schema/get/get_one.coffee
+++ b/test/normal_schema/get/get_one.coffee
@@ -82,7 +82,7 @@ suite 'GET one', ({withModel, withServer}) ->
           extra:
             get: (model) -> "Hello there #{model.get 'name'}!"
         }
-        @resource = new ResourceSchema @model, schema
+        @resource = new ResourceSchema @model, schema, {fat: true}
 
       withServer (app) ->
         app.get '/res/:_id', @resource.get('_id'), @resource.send
@@ -189,10 +189,10 @@ suite 'GET one', ({withModel, withServer}) ->
           name: {type: String, default: 'foo'}
 
       withServer (app) ->
-        @resource = new ResourceSchema @model, {'_id', 'name'}
+        @resource = new ResourceSchema @model, {'_id', 'name'}, {fat: true}
         app.get '/bar/:_id', @resource.get('_id'), @resource.send
 
-      it 'uses the mongoose schema defaults', fibrous ->
+      it 'uses the mongoose schema defaults with the fat model option', fibrous ->
         _id = new mongoose.Types.ObjectId()
         @model.collection.sync.insert {_id}
         response = @request.sync.get "/bar/#{_id}"


### PR DESCRIPTION
We rarely need fat models in our ResourceSchemas and the performance impact on GET requests with lots of results is significant. If you do need to access dynamic getters, use the `fat: true` option.

```coffeescript
person = mongoose.Schema
  name: {type: String, default: 'foo'}

schema =
  name:
    get: (person, context) ->
      ## with `{fat:true}` person is a mongoose object as opposed to a POJO

new ResourceSchema person, schema, {fat: true}

```