### PR TITLE
Handle <index:value> array representation in query

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - '4.2.6'
   - '0.10'
 before_install:
   - curl -sSL https://github.com/goodeggs/travis-utils/raw/master/mongodb.sh | MONGO_VERSION=2.6.4 sh

--- a/test/normal_schema/get/get_many.coffee
+++ b/test/normal_schema/get/get_many.coffee
@@ -542,6 +542,17 @@ suite 'GET many', ({withModel, withServer}) ->
           expect(@response.body[0]).to.have.property 'price', 12
           expect(@response.body[1]).to.have.property 'price', 27
 
+        it 'transforms object array to the array', ->
+          @response = @request.sync.get
+            url: '/products?price[0]=12&price[1]=27&price[2]=10',
+            json: true
+
+          expect(@response.statusCode).to.equal 200
+          expect(@response.body).to.have.length 3
+          expect(@response.body[0]).to.have.property 'price', 10
+          expect(@response.body[1]).to.have.property 'price', 12
+          expect(@response.body[2]).to.have.property 'price', 27
+
       describe 'renamed field', ->
         withModel (mongoose) ->
           mongoose.Schema

--- a/test/support/helpers.coffee
+++ b/test/support/helpers.coffee
@@ -6,7 +6,7 @@ Boom = require 'boom'
 bodyParser = require 'body-parser'
 cookieParser = require 'cookie-parser'
 
-port = process.env.PORT || 93280
+port = process.env.PORT || 65535
 
 suiteHelpers =
   withModel: (args...) ->


### PR DESCRIPTION
Express middleware starts to represent array query params as pairs
of index: value when some array length threshold is reached:

instead of {_id: [elem1, elem2, elem3]} {_id: {'0': elem1, '1': elem2,
  '2': elem3}}

This commit handles this situation, so mongo can successfully handle
such arrays.

@demands