### PR TITLE
support mongo 3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-schema",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Define schemas for RESTful resources from mongoose models, and generate middleware to GET, POST, PUT, and DELETE to those resources.",
   "author": "Good Eggs <open-source@goodeggs.com>",
   "contributors": [

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -135,7 +135,7 @@ module.exports = class ResourceSchema
       limit = @_getLimit req.query
       modelQuery.limit(limit) if limit
 
-      skip = req.query.$skip
+      skip = parseInt(req.query.$skip, 10)
       modelQuery.skip(skip) if skip
 
       sort = @_getSort req.query
@@ -480,9 +480,9 @@ module.exports = class ResourceSchema
   ###
   _getLimit: (query) =>
     if query.$limit?
-      query.$limit
+      parseInt(query.$limit, 10)
     else if @options.limit?
-      @options.limit
+      parseInt(@options.limit, 10)
     else
       1000
 

--- a/test/normal_schema/get/get_many.coffee
+++ b/test/normal_schema/get/get_many.coffee
@@ -549,9 +549,8 @@ suite 'GET many', ({withModel, withServer}) ->
 
           expect(@response.statusCode).to.equal 200
           expect(@response.body).to.have.length 3
-          expect(@response.body[0]).to.have.property 'price', 10
-          expect(@response.body[1]).to.have.property 'price', 12
-          expect(@response.body[2]).to.have.property 'price', 27
+          prices = @response.body.map (product) -> product.price
+          expect(prices).to.include 10, 12, 27
 
       describe 'renamed field', ->
         withModel (mongoose) ->


### PR DESCRIPTION
Mongo 3.2 requires limit and skip arguments to be numbers. resource-schema previously was passing through strings as parsed from the request query string.

fyi @dannynelson 