### PR TITLE
Don't throw away mongoose error details in middleware.

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -843,7 +843,7 @@ module.exports = class ResourceSchema
 
   _handleRequestError: (err, requestContext) ->
     {req, res, next} = requestContext
-    return next boom.badRequest(err.message) if err.name in ['CastError', 'ValidationError']
+    return next boom.badRequest(err) if err.name in ['CastError', 'ValidationError']
     next boom.wrap(err)
 
   _getResourceCount: (mongoQuery, requestContext) ->


### PR DESCRIPTION
e.g. a `ValidationError` has details about the failing paths and how the validation failed